### PR TITLE
Update cli.txt

### DIFF
--- a/cli.txt
+++ b/cli.txt
@@ -4,7 +4,18 @@ Object.defineProperty(exports, '__esModule', { value: true });
 const core_1 = require('@nestjs/core');
 const console_1 = require('@squareboat/nest-console');
 const yargs = require('yargs');
-const app_1 = require('./dist/app.module');
+const fs = require('fs');
+function checkFileExistsSync(filepath){
+  let flag = true;
+  try{fs.accessSync(filepath, fs.constants.F_OK);}catch(e){flag = false;}
+  return flag;
+}
+if (!checkFileExistsSync('./dist/app.module.js')) { // CHANGE THE FILE TO CHECK IF NEEDED
+  console_1.Logger.error(' PLEASE BUILD THE CLI PROJECT FIRST ');
+  console_1.Logger.info(' run: node build '); // CHANGE THE BUILD COMMAND IF NEEDED
+  return process.exit();
+}
+const app_1 = require('./dist/app.module'); // CHANGE THE IMPORT IF NEEDED
 async function bootstrap() {
   const app = await core_1.NestFactory.createApplicationContext(
     app_1.AppModule,


### PR DESCRIPTION
Add a check to display an error message on terminal if the cli project is not still built.
Example:
```
$> node cli hello --name=John
 PLEASE BUILD THE CLI PROJECT FIRST 
 run: nx build cli 
$> nx build cli
...
$> node cli hello --name=John
{ name: 'John' }
Hello John!
```